### PR TITLE
Clear screen and change update time

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@
     <ul>
       <li>Increased size of fonts for "Humidity" and "Wind" for better legibility.</li>
     </ul>
+  <h2>Version 1.7</h2>
+    <ul>
+      <li>Added clear screen function to reduce possibility of burn-in.</li>
+      <li>changed refresh time from 300 to 600 seconds.</li>
+    </ul>
 
 
 

--- a/weather.py
+++ b/weather.py
@@ -222,5 +222,10 @@ while True:
     # Close the template file
     template.close()
     
+    # Refresh clear screen to avoid burn-in at 3:00 AM
+    if datetime.now().strftime('%H') == '03':
+    	print('Clearning screen to avoid burn-in.')
+    	epd.Clear()
+    
     # Write to screen
-    write_to_screen(screen_output_file, 300)
+    write_to_screen(screen_output_file, 600)


### PR DESCRIPTION
Added a clear screen function to ensure screen doesn't have burn-in.
Changed refresh time from 300 to 600 seconds.