### PR TITLE
Enter sleep after refresh to reduce the probability of e-paper damage

### DIFF
--- a/weather.py
+++ b/weather.py
@@ -30,8 +30,11 @@ def write_to_screen(image, sleep_seconds):
     screen_output_file = Image.open(os.path.join(picdir, image))
     # Initialize the drawing context with template as background
     h_image.paste(screen_output_file, (0, 0))
+    epd.init()
     epd.display(epd.getbuffer(h_image))
     # Sleep
+    time.sleep(2)
+    epd.sleep()
     print('Sleeping for ' + str(sleep_seconds) +'.')
     time.sleep(sleep_seconds)
 


### PR DESCRIPTION
It is necessary to enter sleep mode after e-paper refresh.
Otherwise, continuous high voltage may damage the panel.